### PR TITLE
Feat/about post blocks

### DIFF
--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_gray-section.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_gray-section.scss
@@ -1,0 +1,22 @@
+@use '../abstracts' as *;
+
+.wp-block-lazyblock-gray-section {
+  --section-bg: #{$color-bg-light-200};
+}
+
+.csis-block--gray-section {
+  margin: rem(40) auto rem(56);
+  padding-top: rem(32px);
+  padding-bottom: rem(56px);
+  background: var(--section-bg);
+  @include full-width-background(var(--section-bg));
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &::before,
+  &::after {
+    z-index: -1;
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -38,7 +38,7 @@
   .members__list--has-image {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(#{rem(260)}, 1fr));
-    margin: rem(16) 0 rem(16);
+    margin: rem(8) 0 rem(16);
     column-gap: rem(40);
     row-gap: rem(24);
 

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -4,7 +4,6 @@
   a:not([class]) {
     max-width: fit-content;
     color: $color-link-primary-200;
-    @extend %text-style-paragraph-medium-short-caps;
 
     &:hover {
       color: $color-bg-dark-100;
@@ -29,6 +28,10 @@
       column-gap: rem(48);
     }
 
+    a:not([class]) {
+      @extend %text-style-paragraph-medium-short-caps;
+    }
+
     /* stylelint-disable-next-line */
     .members__item + .members__item {
       margin-top: rem(16);
@@ -44,6 +47,10 @@
 
     @include breakpoint('medium') {
       row-gap: rem(32);
+    }
+
+    a:not([class]) {
+      @extend %text-style-label-x-small-strong-caps;
     }
 
     .members__item {

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -1,0 +1,72 @@
+@use '../abstracts' as *;
+
+.wp-block-lazyblock-team-members {
+  a:not([class]) {
+    max-width: fit-content;
+    color: $color-link-primary-200;
+    @extend %text-style-paragraph-medium-short-caps;
+
+    &:hover {
+      color: $color-bg-dark-100;
+    }
+
+    &:focus {
+      color: $color-bg-dark-100;
+      background: $color-bg-light-300;
+      outline: 0;
+    }
+
+    .icon {
+      font-size: 0.8em;
+    }
+  }
+
+  .members__list--no-image {
+    margin: rem(8) 0 rem(40);
+
+    @include breakpoint('small') {
+      column-count: 2;
+      column-gap: rem(48);
+    }
+
+    /* stylelint-disable-next-line */
+    .members__item + .members__item {
+      margin-top: rem(16);
+    }
+  }
+
+  .members__list--has-image {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(#{rem(260)}, 1fr));
+    margin: rem(16) 0 rem(16);
+    column-gap: rem(40);
+    row-gap: rem(24);
+
+    @include breakpoint('medium') {
+      row-gap: rem(32);
+    }
+
+    .members__item {
+      display: grid;
+      grid-template-columns: max-content auto;
+      grid-template-rows: max-content max-content auto;
+      align-items: start;
+      column-gap: rem(16);
+    }
+
+    .members__img {
+      grid-row: 1 / 4;
+    }
+
+    .members__name {
+      color: $color-bg-dark-200;
+      @extend %text-style-paragraph-medium-short-caps;
+    }
+
+    .members__title {
+      margin-bottom: rem(8);
+      color: $color-black-165;
+      @extend %text-style-paragraph-small-short;
+    }
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_partners.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_partners.scss
@@ -1,0 +1,24 @@
+@use '../abstracts' as *;
+
+.wp-block-lazyblock-partners {
+  margin: rem(16) 0 rem(80);
+
+  .csis-block--partners {
+    display: flex;
+    flex-wrap: wrap;
+    gap: rem(40);
+    align-items: center;
+    margin: 0;
+    padding: 0;
+  }
+
+  .partners__item {
+    flex: 1 1 auto;
+    max-width: 225px;
+  }
+
+  img {
+    width: auto;
+    max-height: rem(50);
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -1,6 +1,7 @@
 @use '../abstracts' as *;
 
 @use '../blocks/post/definition-list';
+@use '../blocks/post/gray-section';
 @use '../blocks/post/members';
 
 .single {

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -1,6 +1,7 @@
 @use '../abstracts' as *;
 
 @use '../blocks/post/definition-list';
+@use '../blocks/post/members';
 
 .single {
   // .container {
@@ -64,7 +65,6 @@
   }
 }
 
-.issues-template-default,
 .post-template-default {
   .single__header {
     display: flex;

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -3,6 +3,7 @@
 @use '../blocks/post/definition-list';
 @use '../blocks/post/gray-section';
 @use '../blocks/post/members';
+@use '../blocks/post/partners';
 
 .single {
   // .container {

--- a/wp-content/themes/reconasia/assets/static/icons.svg
+++ b/wp-content/themes/reconasia/assets/static/icons.svg
@@ -60,5 +60,9 @@
 <title>Chevron Right</title>
 <path d="M6.637 6.176l-5.61 5.61-.942-.944 4.667-4.666L.085 1.509l.943-.943 5.61 5.61z" />
 </symbol>
+<symbol id="icon-external-link" viewBox="0 0 14 14">
+<title>External Link</title>
+<path d="M11.39 1.667H8.668V.333h4.057l.014-.014.014.014h.915v.915l.014.014-.014.014v4.057h-1.334V2.61L7 7.943 6.057 7l5.333-5.333z" /><path d="M.333.333v13.334h13.334v-6.99h-1.334v5.656H1.667V1.667h5.485V.333H.333z" />
+</symbol>
 </defs>
 </svg>


### PR DESCRIPTION
Pull request #41 should be resolved first, as this branch is based off of that one. I'll do a rebase if necessary once #41 is merged in.

You'll need to pull down from the reconasiadev site to get the new blocks & updates to the about page. You'll also want to pull in the media files.

* Closes About page member links (#24)
* Closes Team bios block (#23)
* Closes partners block (#26)
* Closes #25 by adding a block for gray section, which is used to create the gray background at the bottom of the about page for the iLab credits (and can be used elsewhere)

I used the same block (Members) for the team bios & the advisory board/scholars list. I made it intentionally reusable so if they ever want to list participants on a panel or other event, they could use this block in the same way. It comes with two options, one to list just the names and one to include the headshots & job title.

The partners block uses `flexbox` to let the browser do the work of resizing & spacing out the logos. Consequently, the order & spacing differs from the mockup. That's okay and we shouldn't worry about it.

Some of the vertical spacing is different from what is in the mockups because the typography for the headings hasn't been applied. Once that's implemented, we should revisit and take a look, but I think this is going to be an area where we'll need to make smart judgement calls, rather than sticking to what is in the mockup.

The blocks expand to take up the available space, and since the about page doesn't have the max width applied, I took screenshots so you would know what they look like at those sizes.

<img width="731" alt="Screen Shot 2021-03-18 at 9 21 56 PM" src="https://user-images.githubusercontent.com/1896496/111718978-5376c600-8831-11eb-820e-9867fae1ee7b.png">

<img width="748" alt="Screen Shot 2021-03-18 at 8 48 16 PM" src="https://user-images.githubusercontent.com/1896496/111718990-5671b680-8831-11eb-9a28-baddb9328524.png">

We should make a note that we should update Hamre, Goodman, and Gabel's headshots so they're square like Jon & Maesea's.