### PR TITLE
Add definition list block

### DIFF
--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_definition-list.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_definition-list.scss
@@ -1,0 +1,23 @@
+@use '../abstracts' as *;
+
+.wp-block-lazyblock-definition-list {
+  margin: rem(16) 0;
+
+  .definition-list {
+    &__item {
+      + .definition-list__item {
+        margin-top: rem(32);
+      }
+    }
+
+    &__term {
+      margin-bottom: rem(8);
+      color: $color-accent-light-primary-100;
+      @extend %text-style-label-large;
+    }
+
+    &__definition {
+      @extend %text-style-paragraph-large-long;
+    }
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_definition-list.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_definition-list.scss
@@ -17,6 +17,7 @@
     }
 
     &__definition {
+      color: $color-black-190;
       @extend %text-style-paragraph-large-long;
     }
   }

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -1,5 +1,7 @@
 @use '../abstracts' as *;
 
+@use '../blocks/post/definition-list';
+
 .single {
   // .container {
   //   @include breakpoint('large') {


### PR DESCRIPTION
You'll want to pull down from reconasiadev to get the lazy blocks & the Glossary page. I only filled out a couple of terms - Maesea's team can add the rest of them.

Closes #27 by creating a block for definition lists. I left it generic so it could be used in other cases where a `<dl>` would be useful. Also some of the spacing around the headings might be off - that'll be resolved once #34 is implemented.