### PR TITLE
Update/component spacing

### DIFF
--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -66,8 +66,8 @@
       grid-template-columns: max-content auto;
       grid-template-rows: max-content max-content auto;
       align-items: start;
-      column-gap: rem(16);
       padding-left: 0;
+      column-gap: rem(16);
     }
 
     .members__img {

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -66,6 +66,7 @@
       grid-template-columns: max-content auto;
       grid-template-rows: max-content max-content auto;
       align-items: start;
+      margin-top: 0;
       padding-left: 0;
       column-gap: rem(16);
     }

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_members.scss
@@ -36,6 +36,10 @@
       @extend %text-style-paragraph-medium-short-caps;
     }
 
+    .members__item {
+      padding-left: 0;
+    }
+
     /* stylelint-disable-next-line */
     .members__item + .members__item {
       margin-top: rem(16);
@@ -63,6 +67,7 @@
       grid-template-rows: max-content max-content auto;
       align-items: start;
       column-gap: rem(16);
+      padding-left: 0;
     }
 
     .members__img {

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_partners.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_partners.scss
@@ -15,6 +15,7 @@
   .partners__item {
     flex: 1 1 auto;
     max-width: 225px;
+    padding-left: 0;
   }
 
   img {

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
@@ -56,11 +56,7 @@
 
     &__title {
       margin-bottom: rem(4);
-      color: $color-black-190;
-
-      &:hover {
-        color: $color-link-primary-200;
-      }
+      // color: $color-black-190;
 
       /* stylelint-disable */
       a[href][href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
@@ -71,10 +67,6 @@
         text-decoration: none;
         box-shadow: none;
         @extend %text-style-label-large-strong;
-
-        &:hover {
-          color: $color-link-primary-200;
-        }
 
         /* stylelint-disable-next-line */
         &:after {

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
@@ -25,7 +25,7 @@
 
       /* stylelint-disable-next-line */
       .csis-block__title a {
-        color: $color-link-primary-200;
+        color: $color-link-primary-200 !important;
       }
     }
 
@@ -56,19 +56,15 @@
 
     &__title {
       margin-bottom: rem(4);
-      // color: $color-black-190;
 
       /* stylelint-disable */
-      a[href][href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
-      {
-        /* stylelint-enable */
+      a:not([class]) {
         color: $color-black-190;
         text-transform: unset;
         text-decoration: none;
         box-shadow: none;
         @extend %text-style-label-large-strong;
 
-        /* stylelint-disable-next-line */
         &:after {
           display: none !important;
         }

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
@@ -58,7 +58,7 @@
       margin-bottom: rem(4);
       color: $color-black-190;
 
-      a {
+      a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"]) {
         color: $color-black-190;
         text-transform: unset;
         box-shadow: none;

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
@@ -22,7 +22,7 @@
         color: $color-white-100;
         background: $color-link-primary-200;
       }
-      
+
       /* stylelint-disable-next-line */
       .csis-block__title a {
         color: $color-link-primary-200;
@@ -58,7 +58,10 @@
       margin-bottom: rem(4);
       color: $color-black-190;
 
-      a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"]) {
+      /* stylelint-disable */
+      a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
+      {
+        /* stylelint-enable */
         color: $color-black-190;
         text-transform: unset;
         box-shadow: none;

--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_publications.scss
@@ -58,14 +58,23 @@
       margin-bottom: rem(4);
       color: $color-black-190;
 
+      &:hover {
+        color: $color-link-primary-200;
+      }
+
       /* stylelint-disable */
-      a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
+      a[href][href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
       {
         /* stylelint-enable */
         color: $color-black-190;
         text-transform: unset;
+        text-decoration: none;
         box-shadow: none;
         @extend %text-style-label-large-strong;
+
+        &:hover {
+          color: $color-link-primary-200;
+        }
 
         /* stylelint-disable-next-line */
         &:after {

--- a/wp-content/themes/reconasia/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/reconasia/assets/_scss/components/_post-block.scss
@@ -87,7 +87,7 @@
         color: $color-accent-dark-primary-400;
 
         &:hover {
-          color: $color-white-100;
+          color: $color-white-100 !important;
         }
 
         &:focus {

--- a/wp-content/themes/reconasia/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/reconasia/assets/_scss/components/_post-block.scss
@@ -17,7 +17,7 @@
   margin-right: auto;
   margin-left: auto;
   color: var(--post-meta);
-  
+
   &.has-post-thumbnail {
     @include breakpoint('medium') {
       grid-template-areas:
@@ -45,7 +45,7 @@
       &:hover {
         color: $color-link-primary-200;
       }
-  
+
       &:focus {
         background: $color-bg-light-400;
       }
@@ -82,12 +82,12 @@
 
     .archive__featured & {
       --post-meta: #{$color-white-190};
-      
+
       a {
-        color: $color-accent-dark-primary-400;
+        color: $color-white-190;
 
         &:hover {
-          color: $color-white-100 !important;
+          color: $color-white-100;
         }
 
         &:focus {

--- a/wp-content/themes/reconasia/assets/_scss/components/_post-meta.scss
+++ b/wp-content/themes/reconasia/assets/_scss/components/_post-meta.scss
@@ -13,14 +13,18 @@
     @extend %text-style-paragraph-small-short;
 
     a {
-      color: $color-link-primary-200;
-      
+      color: $color-black-190;
+
+      &::after {
+        background-image: none;
+      }
+
       &:hover {
-        --post-meta: #{$color-bg-dark-100};
+        color: $color-bg-dark-100;
       }
 
       &:focus {
-        --post-meta: #{$color-bg-dark-100};
+        color: $color-bg-dark-100;
         background: $color-bg-light-300;
       }
     }
@@ -42,7 +46,7 @@
       display: inline;
     }
 
-    li:not(:last-of-type) {  
+    li:not(:last-of-type) {
       &::after {
         content: '';
         margin-right: rem(10);

--- a/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
+++ b/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
@@ -117,16 +117,20 @@
 
     /* stylelint-disable */
     a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])[href*="csis.org/privacy-policy"] {
+      color: $color-white-165;
+      text-transform: unset;
+      font-weight: 400;
+
       &:hover {
         color: $color-white-100;
-
-        &:after {
-          filter: invert(100%) sepia(16%) saturate(0%) hue-rotate(217deg) brightness(106%)    contrast(106%);
-        }
       }
 
       &:focus {
         color: $color-white-100;
+      }
+
+      &:after {
+        display: none;
       }
     }
   }
@@ -140,8 +144,7 @@
     }
   }
 
-  &__newsletter-desc,
-  &__copyright {
+  &__newsletter-desc {
     color: $color-white-165;
   }
 

--- a/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
+++ b/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
@@ -113,6 +113,7 @@
   &__copyright {
     grid-area: copyright;
     margin-top: rem(16);
+    color: $color-white-165;
     text-align: left;
 
     a {

--- a/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
+++ b/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
@@ -115,11 +115,8 @@
     margin-top: rem(16);
     text-align: left;
 
-    /* stylelint-disable */
-    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])[href*="csis.org/privacy-policy"] {
+    a {
       color: $color-white-165;
-      text-transform: unset;
-      font-weight: 400;
 
       &:hover {
         color: $color-white-100;
@@ -127,10 +124,6 @@
 
       &:focus {
         color: $color-white-100;
-      }
-
-      &:after {
-        display: none;
       }
     }
   }

--- a/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
+++ b/wp-content/themes/reconasia/assets/_scss/layout/_footer.scss
@@ -114,6 +114,21 @@
     grid-area: copyright;
     margin-top: rem(16);
     text-align: left;
+
+    /* stylelint-disable */
+    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])[href*="csis.org/privacy-policy"] {
+      &:hover {
+        color: $color-white-100;
+
+        &:after {
+          filter: invert(100%) sepia(16%) saturate(0%) hue-rotate(217deg) brightness(106%)    contrast(106%);
+        }
+      }
+
+      &:focus {
+        color: $color-white-100;
+      }
+    }
   }
 
   &__newsletter {

--- a/wp-content/themes/reconasia/assets/_scss/pages/post.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/post.scss
@@ -88,16 +88,13 @@
     --post-meta: #{$color-white-190};
     margin-bottom: rem(8);
 
-    /* stylelint-disable */
-    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"]) {
+    a {
+      color: $color-white-190;
+
       &:hover {
         color: $color-white-100;
-
-        &:after {
-          filter: invert(100%) sepia(16%) saturate(0%) hue-rotate(217deg) brightness(106%) contrast(106%);
-        }
       }
-  
+
       &:focus {
         color: $color-white-100;
       }

--- a/wp-content/themes/reconasia/assets/_scss/pages/post.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/post.scss
@@ -87,6 +87,21 @@
   .post-meta__authors {
     --post-meta: #{$color-white-190};
     margin-bottom: rem(8);
+
+    /* stylelint-disable */
+    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"]) {
+      &:hover {
+        color: $color-white-100;
+
+        &:after {
+          filter: invert(100%) sepia(16%) saturate(0%) hue-rotate(217deg) brightness(106%) contrast(106%);
+        }
+      }
+  
+      &:focus {
+        color: $color-white-100;
+      }
+    }
   }
 
   .post-meta__date {

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -74,51 +74,52 @@
       color: $color-link-primary-200;
       @extend %text-style-label-large;
     }
+
+    /*----------  Links  ----------*/
+    /* stylelint-disable */
+    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
+    {
+      color: $color-link-primary-200;
+      @extend %text-style-label-small-strong-caps;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: all 0.3s ease-in-out;
+
+      &:hover {
+        color: $color-bg-dark-100;
+      }
+
+      &:focus {
+        color: $color-bg-dark-100;
+        background: $color-bg-light-300;
+      }
+
+      &::after {
+        content: '';
+        position: relative;
+        top: 1px;
+        left: 5px;
+        display: inline-block;
+        width: 0.8em;
+        height: 0.8em;
+        background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
+        background-size: 100% 100%;
+        filter: invert(37%) sepia(92%) saturate(344%) hue-rotate(133deg)
+          brightness(93%) contrast(101%);
+        transition: filter 0.3s ease-in-out;
+      }
+
+      &:hover::after {
+        filter: invert(4%) sepia(6%) saturate(2132%) hue-rotate(176deg)
+          brightness(90%) contrast(96%);
+        opacity: 1 !important;
+      }
+    }
   }
-
-  /*----------  Links  ----------*/
-  /* stylelint-disable */
-  a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
-  {
-    color: $color-link-primary-200;
-    @extend %text-style-label-small-strong-caps;
-    text-transform: uppercase;
-    text-decoration: none;
-    transition: all 0.3s ease-in-out;
-
-    &:hover {
-      color: $color-bg-dark-100;
-    }
-
-    &:focus {
-      color: $color-bg-dark-100;
-      background: $color-bg-light-300;
-    }
-
-    &::after {
-      content: '';
-      position: relative;
-      top: 1px;
-      left: 5px;
-      display: inline-block;
-      width: 0.8em;
-      height: 0.8em;
-      background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
-      background-size: 100% 100%;
-      filter: invert(37%) sepia(92%) saturate(344%) hue-rotate(133deg)
-        brightness(93%) contrast(101%);
-      transition: filter 0.3s ease-in-out;
-    }
-
-    &:hover::after {
-      filter: invert(4%) sepia(6%) saturate(2132%) hue-rotate(176deg) brightness(90%) contrast(96%);
-      opacity: 1 !important;
-    }
-  }
-
 
   .post .single__content p {
-    a[href][href*="//"]:not([class]) {
+    a[href][href*="//"]:not([class])
+    {
       font-family: $font__merriweather;
       @include font-size(18px);
       font-weight: 400;
@@ -219,8 +220,8 @@
         content: '';
         display: block;
         background: $color-black-130;
-        height: .0625rem;
-        width: 2.5rem; 
+        height: 0.0625rem;
+        width: 2.5rem;
         margin-top: 0.75rem;
       }
     }

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -77,10 +77,10 @@
 
     /*----------  Links  ----------*/
     a {
+      color: $color-link-primary-200;
       font-family: $font__merriweather;
       @include font-size(18px);
       font-weight: 400;
-      color: $color-link-primary-200;
       text-decoration: underline;
 
       &:hover {
@@ -90,8 +90,8 @@
 
       &:focus {
         color: $color-accent-light-primary-100;
-        background: $color-bg-light-400;
         text-decoration: none;
+        background: $color-bg-light-400;
       }
     }
 

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -76,56 +76,12 @@
     }
 
     /*----------  Links  ----------*/
-    /* stylelint-disable */
-    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
-    {
-      color: $color-link-primary-200;
-      @extend %text-style-label-small-strong-caps;
-      text-transform: uppercase;
-      text-decoration: none;
-      transition: all 0.3s ease-in-out;
-
-      &:hover {
-        color: $color-bg-dark-100;
-      }
-
-      &:focus {
-        color: $color-bg-dark-100;
-        background: $color-bg-light-300;
-      }
-
-      &::after {
-        content: '';
-        position: relative;
-        top: 1px;
-        left: 5px;
-        display: inline-block;
-        width: 0.8em;
-        height: 0.8em;
-        background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
-        background-size: 100% 100%;
-        filter: invert(37%) sepia(92%) saturate(344%) hue-rotate(133deg)
-          brightness(93%) contrast(101%);
-        transition: filter 0.3s ease-in-out;
-      }
-
-      &:hover::after {
-        filter: invert(4%) sepia(6%) saturate(2132%) hue-rotate(176deg)
-          brightness(90%) contrast(96%);
-        opacity: 1 !important;
-      }
-    }
-  }
-
-  .post .single__content p {
-    a[href][href*="//"]:not([class])
-    {
+    a {
       font-family: $font__merriweather;
       @include font-size(18px);
       font-weight: 400;
       color: $color-link-primary-200;
       text-decoration: underline;
-      text-transform: unset;
 
       &:hover {
         color: $color-accent-light-primary-100;
@@ -137,14 +93,30 @@
         background: $color-bg-light-400;
         text-decoration: none;
       }
+    }
 
-      &:visited {
-        color: $color-accent-light-primary-100;
-        text-decoration: underline;
+    /* stylelint-disable */
+    a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
+    {
+      /* stylelint-enable */
+      &::after {
+        content: '';
+        position: relative;
+        top: 1px;
+        left: 5px;
+        display: inline-block;
+        width: 0.8em;
+        height: 0.8em;
+        background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
+        background-size: 100% 100%;
+        filter: invert(38%) sepia(89%) saturate(439%) hue-rotate(133deg)
+          brightness(86%) contrast(85%);
+        transition: filter 0.3s ease-in-out;
       }
 
-      &:after {
-        display: none;
+      &:hover::after {
+        filter: invert(33%) sepia(14%) saturate(1559%) hue-rotate(131deg)
+          brightness(95%) contrast(87%);
       }
     }
   }
@@ -167,9 +139,11 @@
       }
 
       tbody {
+        /* stylelint-disable-next-line */
         tr:nth-child(even) {
           background-color: $color-bg-tbody;
         }
+        /* stylelint-disable-next-line */
         tr:nth-child(odd) {
           background-color: $color-white-100;
         }
@@ -179,10 +153,12 @@
         border-top: 1px solid $color-black-115;
       }
 
+      /* stylelint-disable */
       table td + td,
       table th + th {
         border-left: 1px solid $color-black-115;
       }
+      /* stylelint-enable */
 
       td {
         border-bottom: 1px solid $color-black-115;
@@ -200,9 +176,10 @@
     thead {
       @extend %text-style-label-large-strong;
 
+      /* stylelint-disable-next-line */
       th {
-        border-bottom: 1px solid $color-black-130 !important;
         text-align: left;
+        border-bottom: 1px solid $color-black-130 !important;
       }
     }
 
@@ -212,17 +189,17 @@
     }
 
     figcaption {
+      margin-top: 0.75rem;
       color: $color-black-165;
       @extend %text-style-label-medium;
-      margin-top: 0.75rem;
 
-      &:after {
+      &::after {
         content: '';
         display: block;
-        background: $color-black-130;
-        height: 0.0625rem;
         width: 2.5rem;
+        height: 0.0625rem;
         margin-top: 0.75rem;
+        background: $color-black-130;
       }
     }
   }

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -121,6 +121,9 @@
 
   .post {
     p > a {
+      font-family: $font__merriweather;
+      @include font-size(18px);
+      font-weight: 400;
       color:$color-link-primary-200;
       text-decoration: underline;
       text-transform: unset;

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -76,7 +76,7 @@
     }
 
     /*----------  Links  ----------*/
-    a {
+    a:not([class]) {
       color: $color-link-primary-200;
       font-family: $font__merriweather;
       @include font-size(18px);
@@ -104,6 +104,7 @@
         position: relative;
         top: 1px;
         left: 5px;
+        margin-right: 5px;
         display: inline-block;
         width: 0.8em;
         height: 0.8em;

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -104,10 +104,10 @@
         position: relative;
         top: 1px;
         left: 5px;
-        margin-right: 5px;
         display: inline-block;
         width: 0.8em;
         height: 0.8em;
+        margin-right: 5px;
         background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
         background-size: 100% 100%;
         filter: invert(38%) sepia(89%) saturate(439%) hue-rotate(133deg)

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -77,8 +77,9 @@
   }
 
   /*----------  Links  ----------*/
-
-  a:not([class]) {
+  /* stylelint-disable */
+  a[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
+  {
     color: $color-link-primary-200;
     @extend %text-style-label-small-strong-caps;
     text-transform: uppercase;
@@ -94,37 +95,34 @@
       background: $color-bg-light-300;
     }
 
-    /* stylelint-disable */
-    &[href*="//"]:not([class]):not([href*="reconasia.local"]):not([href*="localhost"]):not([href*="reconasia"])
-    {
-      &::after {
-        content: '';
-        position: relative;
-        top: 1px;
-        left: 5px;
-        display: inline-block;
-        width: 0.8em;
-        height: 0.8em;
-        background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
-        background-size: 100% 100%;
-        filter: invert(37%) sepia(92%) saturate(344%) hue-rotate(133deg)
-          brightness(93%) contrast(101%);
-        transition: filter 0.3s ease-in-out;
-      }
+    &::after {
+      content: '';
+      position: relative;
+      top: 1px;
+      left: 5px;
+      display: inline-block;
+      width: 0.8em;
+      height: 0.8em;
+      background-image: url('/wp-content/themes/reconasia/assets/static/icons/arrow-external.svg');
+      background-size: 100% 100%;
+      filter: invert(37%) sepia(92%) saturate(344%) hue-rotate(133deg)
+        brightness(93%) contrast(101%);
+      transition: filter 0.3s ease-in-out;
+    }
 
-      &:hover::after {
-        filter: invert(4%) sepia(6%) saturate(2132%) hue-rotate(176deg) brightness(90%) contrast(96%);
-        opacity: 1 !important;
-      }
+    &:hover::after {
+      filter: invert(4%) sepia(6%) saturate(2132%) hue-rotate(176deg) brightness(90%) contrast(96%);
+      opacity: 1 !important;
     }
   }
 
-  .post {
-    p > a {
+
+  .post .single__content p {
+    a[href][href*="//"]:not([class]) {
       font-family: $font__merriweather;
       @include font-size(18px);
       font-weight: 400;
-      color:$color-link-primary-200;
+      color: $color-link-primary-200;
       text-decoration: underline;
       text-transform: unset;
 
@@ -145,7 +143,7 @@
       }
 
       &:after {
-        display: none !important;
+        display: none;
       }
     }
   }

--- a/wp-content/themes/reconasia/inc/template-functions.php
+++ b/wp-content/themes/reconasia/inc/template-functions.php
@@ -331,13 +331,14 @@ if ( class_exists( 'easyFootnotes' ) ) {
 function reconasia_exclude_related__posts_from_archive( $query ) {
 
 	if ( $query->is_main_query() && ! is_admin() && is_archive() ) {
+        $term = get_queried_object();
 		$featured_post = get_field( 'featured_post', $term );
 
 		if ( $featured_post ) {
 				$excluded_post_ids = array();
 
 				foreach ($featured_post as $post) {
-					$excluded_post_ids[] = $post;
+					$excluded_post_ids[] = $post->ID;
 				}
 
 			$query->set( 'post__not_in', $excluded_post_ids);

--- a/wp-content/themes/reconasia/template-parts/content.php
+++ b/wp-content/themes/reconasia/template-parts/content.php
@@ -29,7 +29,6 @@
 
 	<footer class="single__footer">
 		<?php get_template_part( 'template-parts/featured-image-caption' ); ?>
-		<?php if ( function_exists( 'ADDTOANY_SHARE_SAVE_KIT' ) ) { ADDTOANY_SHARE_SAVE_KIT(); } ?>
 		<?php echo reconasia_authors_list_extended(); ?>
 	</footer>
 


### PR DESCRIPTION
Revised link styling to ensure that base component styling does not overwrite other components as there are a variety of different link styles.

Base styles for external links that have dark background were provided more specificity in their selectors to overwrite base light background styling. Light background styling was chosen as base because it appears on more components than dark styling. 

*Down for a brainstorm session if there is a better way to move forward on this. Currently all the styles are applying accurately across the site. 

Revised spacing on components as needed.