### PR TITLE
Bug/archive styles

### DIFF
--- a/wp-content/themes/reconasia/archive.php
+++ b/wp-content/themes/reconasia/archive.php
@@ -7,6 +7,8 @@
  * @since 1.0.0
  */
 
+$term = get_queried_object();
+
 get_header();
 ?>
 
@@ -14,13 +16,16 @@ get_header();
 
 	<?php
 		get_template_part( 'template-parts/entry-header' );
+	?>
 
+	<div class='archive__content'>
+
+	<?php
 		if ( have_posts() ) {
 			reconasia_pagination_number_of_posts();
 		}
 
 		if (class_exists('ACF') && !is_paged()) {
-			$term = get_queried_object();
 			// vars
 			$featured_post = get_field('featured_post', $term);
 			if ( $featured_post ) {
@@ -50,32 +55,36 @@ get_header();
 		}
 		get_template_part( 'template-parts/pagination' );
 
-		$term = get_queried_object();
-		$cards = get_field('card', $term);
+		if (class_exists('ACF') && !is_paged()) {
+			$cards = get_field('card', $term);
 
-		if( $cards ) { ?>
-			<div class="cards__container">
-			<?php foreach( $cards as $card) { 
-				if ( $card['card_description'] ) {
+			if ( $cards ) { ?>
+				<div class="cards__container">
+				<?php foreach( $cards as $card) {
+					if ( $card['card_description'] ) {
 
-					$link = $card['page_link'];
-					?>
-				<div class='card' style="background-image: url('<?php echo esc_url($card['background_image']); ?>');">
-					<div class="card__wrapper">
-						<a href="<?php echo esc_url($link['url'])  ?>" class="card__link">
-							<?php if($card['card_title']) {
-								echo '<h2 class="card__title">' . $card['card_title'] . '</h2>';
-							} else {
-								echo '<h2 class="card__title">' . $link['title'] . '</h2>';
-							} ?>
-							<?php echo '<p class="card__description">' . reconasia_get_svg( 'single-arrow' ) . $card['card_description'] . '</p>'; ?>
-						</a>
-					</div><!-- .card__wrapper -->
-				</div><!-- .card -->
-			<?php }
-			} ?>
-		</div><!-- .cards__container -->
-		<?php } ?>
+						$link = $card['page_link'];
+						?>
+					<div class='card' style="background-image: url('<?php echo esc_url($card['background_image']); ?>');">
+						<div class="card__wrapper">
+							<a href="<?php echo esc_url($link['url'])  ?>" class="card__link">
+								<?php if($card['card_title']) {
+									echo '<h2 class="card__title">' . $card['card_title'] . '</h2>';
+								} else {
+									echo '<h2 class="card__title">' . $link['title'] . '</h2>';
+								} ?>
+								<?php echo '<p class="card__description">' . reconasia_get_svg( 'single-arrow' ) . $card['card_description'] . '</p>'; ?>
+							</a>
+						</div><!-- .card__wrapper -->
+					</div><!-- .card -->
+				<?php }
+				} ?>
+			</div><!-- .cards__container -->
+			<?php
+			}
+		}
+	?>
+	</div>
 
 </main><!-- #site-content -->
 

--- a/wp-content/themes/reconasia/archive.php
+++ b/wp-content/themes/reconasia/archive.php
@@ -66,16 +66,14 @@ get_header();
 						$link = $card['page_link'];
 						?>
 					<div class='card' style="background-image: url('<?php echo esc_url($card['background_image']); ?>');">
-						<div class="card__wrapper">
-							<a href="<?php echo esc_url($link['url'])  ?>" class="card__link">
-								<?php if($card['card_title']) {
-									echo '<h2 class="card__title">' . $card['card_title'] . '</h2>';
-								} else {
-									echo '<h2 class="card__title">' . $link['title'] . '</h2>';
-								} ?>
-								<?php echo '<p class="card__description">' . reconasia_get_svg( 'single-arrow' ) . $card['card_description'] . '</p>'; ?>
-							</a>
-						</div><!-- .card__wrapper -->
+						<a href="<?php echo esc_url($link['url'])  ?>" class="card__link">
+							<?php if($card['card_title']) {
+								echo '<h2 class="card__title">' . $card['card_title'] . '</h2>';
+							} else {
+								echo '<h2 class="card__title">' . $link['title'] . '</h2>';
+							} ?>
+							<?php echo '<p class="card__description">' . reconasia_get_svg( 'single-arrow' ) . $card['card_description'] . '</p>'; ?>
+						</a>
 					</div><!-- .card -->
 				<?php }
 				} ?>

--- a/wp-content/themes/reconasia/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/reconasia/assets/_scss/abstracts/_variables.scss
@@ -84,6 +84,7 @@ $container-width-diff: 57.5rem; // Difference in rems between small & large brea
 $size__container-max-width: 1400px;
 $size__content-max-width: 680px;
 $size__content-wide-max-width: 1200px;
+$size__archive-max-width: 900px;
 
 /*----------  Z-Index  ----------*/
 $z-index: (
@@ -108,4 +109,3 @@ $shadows: (
 $shadow--1: drop-shadow(0 3px 4px rgba(2, 3, 3, 0.03))
   drop-shadow(0 3px 3px rgba(2, 3, 3, 0.02))
   drop-shadow(0 1px 8px rgba(2, 3, 3, 0.04));
-

--- a/wp-content/themes/reconasia/assets/_scss/components/_entry-header.scss
+++ b/wp-content/themes/reconasia/assets/_scss/components/_entry-header.scss
@@ -2,11 +2,12 @@
 
 .entry-header {
   --header-margin-bottom: #{rem(32)};
-  $cutout-width: 45px;
+  --cutout-width: #{rem(36)};
+  --cutout-height: #{rem(24)};
 
   position: relative;
   max-width: $size__content-max-width;
-  margin: 0 auto calc(var(--header-margin-bottom) + #{$cutout-width});
+  margin: 0 auto calc(var(--header-margin-bottom) + var(--cutout-width));
   padding: rem(24) 0 rem(32);
   text-align: center;
 
@@ -16,6 +17,8 @@
   }
 
   @include breakpoint('large') {
+    --cutout-width: #{rem(45)};
+    --cutout-height: #{rem(30)};
     padding-top: rem(16);
   }
 
@@ -42,7 +45,7 @@
     display: block;
     width: 0;
     height: 0;
-    border-width: 30px ($cutout-width / 2) 0;
+    border-width: var(--cutout-height) calc(var(--cutout-width) / 2) 0;
     border-style: solid;
     border-color: $color-page-header-triangle transparent transparent
       transparent;

--- a/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
@@ -4,6 +4,12 @@
 .archive {
   background: $color-bg-light-200;
 
+  &__content {
+    max-width: $size__archive-max-width;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
   &__featured {
     position: relative;
     margin: 0 calc(var(--container-padding) * -1);
@@ -75,12 +81,6 @@
         }
       }
 
-      // @include breakpoint('small') {
-      //   padding-right: rem(24);
-      //   padding-bottom: rem(24);
-      //   padding-left: rem(24);
-      // }
-
       @include breakpoint('medium') {
         @include shadow('lg');
       }
@@ -117,15 +117,10 @@
   }
 
   &__results {
-    margin-top: rem(32);
     margin-bottom: rem(40);
     padding-bottom: rem(8);
     color: $color-black-190;
     border-bottom: 1px solid $color-border-dark-130;
-
-    @include breakpoint('medium') {
-      margin-top: rem(40);
-    }
 
     @include breakpoint('large') {
       padding-bottom: rem(16);

--- a/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
@@ -88,11 +88,14 @@
       @include breakpoint('large') {
         margin-bottom: rem(8);
         padding: rem(48);
+        column-gap: rem(40);
       }
     }
   }
 
   &__base {
+    margin-bottom: rem(40);
+
     @include shadow('lg');
 
     @include breakpoint('small') {
@@ -105,6 +108,7 @@
 
     @include breakpoint('large') {
       margin-top: rem(56);
+      margin-bottom: rem(56);
     }
   }
 }
@@ -234,18 +238,28 @@
   background-repeat: no-repeat;
   background-size: cover;
 
-  &__wrapper {
+  &__link {
+    display: block;
     max-width: rem(400);
     margin: auto;
     padding: rem(24);
     background-color: $color-bg-dark-290;
     @include shadow(md);
+
+    &:hover .card__title {
+      color: $color-link-primary-200;
+    }
+
+    &:focus .card__title {
+      background: $color-bg-light-400;
+    }
   }
 
   &__title {
     @extend %text-style-heading-large-strong;
     margin-bottom: rem(12);
     color: $color-white-100;
+    transition: color 0.3s ease-in-out;
   }
 
   .icon {

--- a/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/archive.scss
@@ -8,6 +8,14 @@
     max-width: $size__archive-max-width;
     margin-right: auto;
     margin-left: auto;
+
+    > *:not(.cards__container):last-child {
+      margin-bottom: rem(40);
+
+      @include breakpoint('large') {
+        margin-bottom: rem(56);
+      }
+    }
   }
 
   &__featured {
@@ -94,8 +102,6 @@
   }
 
   &__base {
-    margin-bottom: rem(40);
-
     @include shadow('lg');
 
     @include breakpoint('small') {
@@ -108,7 +114,6 @@
 
     @include breakpoint('large') {
       margin-top: rem(56);
-      margin-bottom: rem(56);
     }
   }
 }
@@ -225,10 +230,12 @@
 }
 
 .cards__container {
+  margin-top: rem(40);
   @include csis-block-full-width-wrapper;
 
   @include breakpoint('large') {
     display: flex;
+    margin-top: rem(56);
   }
 }
 

--- a/wp-content/themes/reconasia/functions.php
+++ b/wp-content/themes/reconasia/functions.php
@@ -172,11 +172,11 @@ wp_enqueue_style( 'reconasia-fonts', 'https://fonts.googleapis.com/css2?family=L
 
 	wp_enqueue_style( 'reconasia-style', get_stylesheet_directory_uri() . '/style.min.css', array(), $theme_version );
 
-	if ( is_front_page() || is_home() ) {
+	if ( is_front_page() ) {
 		wp_enqueue_style( 'reconasia-style-home', get_stylesheet_directory_uri() . '/assets/css/pages/home.min.css', array(), $theme_version );
 	}
 
-	if ( is_archive() || is_search() ) {
+	if ( is_archive() || is_search() || is_home() ) {
 		wp_enqueue_style( 'reconasia-style-archive', get_stylesheet_directory_uri() . '/assets/css/pages/archive.min.css', array(), $theme_version );
 	}
 

--- a/wp-content/themes/reconasia/inc/template-functions.php
+++ b/wp-content/themes/reconasia/inc/template-functions.php
@@ -36,8 +36,8 @@ function reconasia_body_classes( $classes ) {
 	global $post;
 	$post_type = isset( $post ) ? $post->post_type : false;
 
-	// Check if we're the "blog page"
-	if ( is_home() ) {
+	// Check if we're the "blog page" or search page, and make them look like the archives.
+	if ( is_home() || is_search() ) {
 		$classes[] = 'archive';
 	}
 

--- a/wp-content/themes/reconasia/inc/template-functions.php
+++ b/wp-content/themes/reconasia/inc/template-functions.php
@@ -36,6 +36,11 @@ function reconasia_body_classes( $classes ) {
 	global $post;
 	$post_type = isset( $post ) ? $post->post_type : false;
 
+	// Check if we're the "blog page"
+	if ( is_home() ) {
+		$classes[] = 'archive';
+	}
+
 	// Check whether we're singular.
 	if ( is_singular() ) {
 		$classes[] = 'singular';

--- a/wp-content/themes/reconasia/index.php
+++ b/wp-content/themes/reconasia/index.php
@@ -14,31 +14,55 @@
  * @since 1.0.0
  */
 
+$term = get_queried_object();
+
 get_header();
 ?>
 
 <main id="site-content" role="main">
 
 	<?php
-
 		get_template_part( 'template-parts/entry-header' );
+	?>
 
+	<div class='archive__content'>
 
+	<?php
 		if ( have_posts() ) {
-
 			reconasia_pagination_number_of_posts();
-
-			while ( have_posts() ) {
-				the_post();
-
-				get_template_part( 'template-parts/block', get_post_type() );
-
-			}
-			wp_reset_postdata();
 		}
 
-	get_template_part( 'template-parts/pagination' );
+		if (class_exists('ACF') && !is_paged()) {
+			// vars
+			$featured_post = get_field('featured_post', $term);
+			if ( $featured_post ) {
+
+				echo '<section class="archive__featured">';
+					echo '<h2 class="archive__featured-label">Featured</h2>';
+					foreach( $featured_post as $post ):
+						// Setup this post for WP functions (variable must be named $post).
+						setup_postdata($post);
+						// get_template_part( 'template-parts/block-post-featured' );
+						get_template_part( 'template-parts/block', get_post_type() );
+					endforeach;
+				echo "</section>";
+				// Reset the global post object so that the rest of the page works correctly.
+				wp_reset_postdata();
+			}
+		}
+
+		if ( have_posts() ) {
+			echo '<section class="archive__base">';
+			while ( have_posts() ) {
+				the_post();
+				get_template_part( 'template-parts/block', get_post_type() );
+			}
+			echo "</section>";
+			wp_reset_postdata();
+		}
+		get_template_part( 'template-parts/pagination' );
 	?>
+	</div>
 
 </main><!-- #site-content -->
 

--- a/wp-content/themes/reconasia/search.php
+++ b/wp-content/themes/reconasia/search.php
@@ -26,6 +26,7 @@ get_header();
 
 			reconasia_pagination_number_of_posts();
 
+			echo '<section class="archive__base">';
 			while ( have_posts() ) {
 				the_post();
 
@@ -33,6 +34,7 @@ get_header();
 
 			}
 			wp_reset_postdata();
+			echo '</section>';
 
 		} elseif ( is_search() ) {
 			?>

--- a/wp-content/themes/reconasia/search.php
+++ b/wp-content/themes/reconasia/search.php
@@ -16,6 +16,12 @@ get_header();
 
 		get_template_part( 'template-parts/entry-header' );
 
+	?>
+
+	<div class='archive__content'>
+
+	<?php
+
 		if ( have_posts() ) {
 
 			reconasia_pagination_number_of_posts();
@@ -48,6 +54,8 @@ get_header();
 
 		get_template_part( 'template-parts/pagination' );
 	?>
+
+	</div>
 
 </main><!-- #site-content -->
 

--- a/wp-content/themes/reconasia/template-parts/entry-header.php
+++ b/wp-content/themes/reconasia/template-parts/entry-header.php
@@ -13,6 +13,7 @@ $has_thumbnail = has_post_thumbnail();
 $post_type = get_post_type();
 $is_404 = is_404();
 $is_search = is_search();
+$is_home = is_home();
 
 $template = get_page_template_slug( get_the_ID() );
 $isNoImageTemplate = false;
@@ -27,12 +28,17 @@ if ( $template === 'templates/template-no-image.php' ){
 
 	<?php
 
-		if ( $is_archive) {
+		if ( $is_archive ) {
 
 			the_archive_title( '<h1 class="entry-header__title">', '</h1>' );
 
 			the_archive_description('<div class="entry-header__desc">', '</div>');
 
+		} elseif ( $is_home ) {
+			$title = get_queried_object()->post_title;
+		?>
+			<h1 class="entry-header__title"><?php echo wp_kses_post( $title ); ?></h1>
+		<?php
 		} elseif ( $is_search ) {
 
 			$archive_title = sprintf(


### PR DESCRIPTION
This does a bunch of things in #64 

- Sets the max width of the archive content to 900px
- Updates the spacing between the entry header & the pagination
- Fixes the column gap on the featured images
- Adds space between the bottom of the archive & the footer, and/or the bottom of the archive & the maps & data cards
  - Note that in order to do this, I had to change the "min" number on the the maps & data field group to 0, and then remove it from the other categories. Otherwise, `$cards` was never empty - it just didn't contain anything, which resulted in the card container still being rendered
 - I updated the map cards so the whole black section is a link, and updated the hover state
 - I updated the search & Analysis page to both look like the archive