### PR TITLE
Single post style tweaks

### DIFF
--- a/wp-content/themes/reconasia/assets/_scss/components/_share.scss
+++ b/wp-content/themes/reconasia/assets/_scss/components/_share.scss
@@ -33,7 +33,6 @@
 
     &:hover {
       --icon-fill: var(--icon-fill-hover);
-      color: var(--icon-fill-hover);
 
       img {
         opacity: 0.9 !important;
@@ -46,6 +45,7 @@
 
     img {
       filter: var(--icon-fill);
+      transition: filter 0.3s ease-in-out;
     }
   }
 

--- a/wp-content/themes/reconasia/assets/_scss/pages/page.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/page.scss
@@ -1,3 +1,12 @@
 @use '../abstracts' as *;
 
 @use '../components/entry-header';
+
+.single__content {
+  margin-bottom: rem(56);
+
+  // If the last child is the gray section block, offset the margin-bottom so the gray section sits flush against the site footer.
+  :last-child.wp-block-lazyblock-gray-section {
+    margin-bottom: rem(-56);
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -171,8 +171,7 @@
 
     table {
       width: 100%;
-      margin-top: rem(16px);
-      margin-bottom: rem(8px);
+      margin-bottom: rem(24);
       @extend %text-style-paragraph-large-short-sans;
       border-collapse: collapse;
     }


### PR DESCRIPTION
Works on a few bugs from #64 

- Adjusts the margin on tables so there's margin bottom (this might need to be further adjusted based on how they actually end up using tables)
- Added transition to share icons
- Added space between the page content and the site footer on pages, unless the page content ends with the gray section block (like on the about page)