### PR TITLE
Add llink to author's archive page

### DIFF
--- a/wp-content/themes/reconasia/inc/template-tags.php
+++ b/wp-content/themes/reconasia/inc/template-tags.php
@@ -189,9 +189,9 @@ function reconasia_last_updated() {
  */
 function reconasia_authors() {
 	if ( function_exists( 'coauthors' ) ) {
-    $authors = coauthors_links( ', ', ', ', null, null, false );
+		$authors = coauthors_posts_links( ', ', ' and ', null, null, false );
 	} else {
-		$authors = get_the_author();
+		$authors = the_author_posts_link();
 	}
 
 	if ( !$authors ) {


### PR DESCRIPTION
-Redirects author to authors archive
- The function below I do not believe is used anywhere. Would you confirm this? If so, I will remove it. 
```
if (! function_exists('reconasia_authors_list_extended')) :
	/**
	 * Prints HTML with short author list.
	 */
	function reconasia_authors_list_extended()
	{
		global $post;
		if ( 'post' !== get_post_type() ) {
			return;
		}
		if (function_exists('coauthors_posts_links')) {
			$authors = '<h2 class="section__heading">Authors</h2>' ...............
```