### PR TITLE
Add filter to remove specified categories from posts

### DIFF
--- a/wp-content/themes/reconasia/functions.php
+++ b/wp-content/themes/reconasia/functions.php
@@ -618,3 +618,13 @@ function reconasia_filter_excerpt ($post_excerpt) {
   return $post_excerpt;
 }
 add_filter ('get_the_excerpt','reconasia_filter_excerpt');
+
+/**
+ * Add options page for advanced custom fields.
+ */
+
+if( function_exists('acf_add_options_page') ) {
+	
+	acf_add_options_page();
+	
+}

--- a/wp-content/themes/reconasia/inc/template-functions.php
+++ b/wp-content/themes/reconasia/inc/template-functions.php
@@ -353,3 +353,29 @@ function jetpackme_more_related_posts( $options ) {
 	return $options;
 	}
 	add_filter( 'jetpack_relatedposts_filter_options', 'jetpackme_more_related_posts' );
+
+
+	/**
+ * Remove certain categories on post loop for a specific post
+ * @param array $categories Array of categories
+ * @return array $categories filtred categories
+ * Adapted from https://developer.wordpress.org/reference/hooks/get_the_categories/#user-contributed-notes
+ */
+function reconasia_remove_selected_categories( $categories ) {
+	$term = get_queried_object();
+	$excluded_topics = get_field( 'excluded_topic', $term );
+	$excluded_topic_names = array();
+
+	foreach ( $excluded_topics as $topic ) {
+		$excluded_topic_names[] = $topic->slug;
+	}
+
+	foreach ( $categories as $index => $single_cat ) {
+		if ( in_array( $single_cat->slug, $excluded_topic_names ) ) {
+				unset( $categories[ $index ] ); // Remove the category.
+		}
+	}
+
+	return $categories;
+}
+add_filter( 'get_the_categories', 'reconasia_remove_selected_categories' );

--- a/wp-content/themes/reconasia/inc/template-functions.php
+++ b/wp-content/themes/reconasia/inc/template-functions.php
@@ -358,14 +358,13 @@ function jetpackme_more_related_posts( $options ) {
 	/**
  * Remove certain categories on post loop for a specific post
  * @param array $categories Array of categories
- * @return array $categories filtred categories
+ * @return array $categories filtered categories
  * Adapted from https://developer.wordpress.org/reference/hooks/get_the_categories/#user-contributed-notes
  */
 function reconasia_remove_selected_categories( $categories ) {
-	$term = get_queried_object();
-	$excluded_topics = get_field( 'excluded_topic', $term );
+	$excluded_topics = get_field( 'excluded_topic', 'option' );
 	$excluded_topic_names = array();
-
+	
 	foreach ( $excluded_topics as $topic ) {
 		$excluded_topic_names[] = $topic->slug;
 	}


### PR DESCRIPTION
Closes #79 
You'll need to pull from dev for this PR.
I borrowed from this [example](https://developer.wordpress.org/reference/hooks/get_the_categories/#user-contributed-notes).