### PR TITLE
Interactive block width

### DIFF
--- a/wp-content/themes/reconasia/assets/_scss/blocks/post/_interactive.scss
+++ b/wp-content/themes/reconasia/assets/_scss/blocks/post/_interactive.scss
@@ -1,0 +1,7 @@
+@use '../abstracts' as *;
+
+.csis-block--interactive {
+  iframe {
+    width: 100% !important;
+  }
+}

--- a/wp-content/themes/reconasia/assets/_scss/pages/single.scss
+++ b/wp-content/themes/reconasia/assets/_scss/pages/single.scss
@@ -2,6 +2,7 @@
 
 @use '../blocks/post/definition-list';
 @use '../blocks/post/gray-section';
+@use '../blocks/post/interactive';
 @use '../blocks/post/members';
 @use '../blocks/post/partners';
 @use '../components/post-block-related';


### PR DESCRIPTION
Set `width: 100% !important` to override the inline width that is being applied to the block.  I added both of you as reviewers, since I couldn't figure out why the inline width was being added, but maybe you can.